### PR TITLE
More helpful exception when missing plugin config.

### DIFF
--- a/classes/marvelapi.php
+++ b/classes/marvelapi.php
@@ -17,6 +17,7 @@
 namespace tool_powerusers;
 
 use moodle_exception;
+use moodle_url;
 use stdClass;
 
 /**
@@ -41,7 +42,8 @@ class marvelapi {
         $publickey = get_config('tool_powerusers', 'marvelpublickey');
 
         if (empty($privatekey) || empty($publickey)) {
-            throw new moodle_exception(get_string('errorkeys', 'tool_powerusers'));
+            throw new moodle_exception('errorkeys', 'tool_powerusers',
+                new moodle_url('/admin/settings.php', ['section' => 'tool_powerusers_settings']));
         }
 
         $name = str_replace( ' ', '%20', trim($name));


### PR DESCRIPTION
Because it makes setup easier on a brand new site, when you're testing someones new user system report :stuck_out_tongue_closed_eyes: 